### PR TITLE
Resolve the module path using resolve.modules from webpack.config.js

### DIFF
--- a/src/resolve-module.js
+++ b/src/resolve-module.js
@@ -37,27 +37,25 @@ function loadModuleRoots(basedir) {
         roots = [ roots ]
     }
 
+    // make paths absolute and return them
     const packageDir = path.dirname(packagePath)
     return roots.map(r => path.resolve(packageDir, r))
 }
 
 
-function resolveWithCustomRoots(basedir, absoluteModule, options) {
-    const { extensions = defaultExtensions } = options
+function resolveWithCustomRoots(basedir, absoluteModule, resolveOptions) {
     const moduleName = `./${absoluteModule}`
 
     const roots = loadModuleRoots(basedir)
+    if (!roots) {
+        return
+    }
 
-    if (roots) {
-        const resolveOptions = { basedir, extensions }
-        for (let i = 0; i < roots.length; i++) {
-            resolveOptions.basedir = roots[i]
-
-            try {
-                return resolve(moduleName, resolveOptions)
-            } catch (e) {
-                /* do nothing */
-            }
+    for (let i = 0; i < roots.length; i++) {
+        try {
+            return resolve(moduleName, { ...resolveOptions, basedir: roots[i] })
+        } catch (e) {
+            /* do nothing */
         }
     }
 }
@@ -90,7 +88,7 @@ export default function resolveModule(filePath, suggestion, options = {}) {
 
         filename = path.join(basedir, moduleName)
     } else if (!filename) {
-        filename = resolveWithCustomRoots(basedir, moduleName, options)
+        filename = resolveWithCustomRoots(basedir, moduleName, resolveOptions)
     }
 
     return { filename }

--- a/src/resolve-module.js
+++ b/src/resolve-module.js
@@ -7,14 +7,14 @@ import { sync as resolve } from 'resolve'
 // Default comes from Node's `require.extensions`
 const defaultExtensions = [ '.js', '.json', '.node' ]
 
-function findPackageJson(basedir) {
-    const packagePath = path.resolve(basedir, 'package.json')
+function findRecursively(basedir, fileName) {
+    const packagePath = path.resolve(basedir, fileName)
     try {
         fs.accessSync(packagePath)
     } catch (e) {
         const parent = path.resolve(basedir, '../')
-        if (parent != basedir) {
-            return findPackageJson(parent)
+        if (parent !== basedir) {
+            return findRecursively(parent, fileName)
         }
         return undefined
     }
@@ -22,7 +22,7 @@ function findPackageJson(basedir) {
 }
 
 function loadModuleRoots(basedir) {
-    const packagePath = findPackageJson(basedir)
+    const packagePath = findRecursively(basedir, 'package.json')
     if (!packagePath) {
         return
     }

--- a/src/resolve-module.js
+++ b/src/resolve-module.js
@@ -8,9 +8,9 @@ import { sync as resolve } from 'resolve'
 const defaultExtensions = [ '.js', '.json', '.node' ]
 
 function findRecursively(basedir, fileName) {
-    const packagePath = path.resolve(basedir, fileName)
+    const configPath = path.resolve(basedir, fileName)
     try {
-        fs.accessSync(packagePath)
+        fs.accessSync(configPath)
     } catch (e) {
         const parent = path.resolve(basedir, '../')
         if (parent !== basedir) {
@@ -18,17 +18,17 @@ function findRecursively(basedir, fileName) {
         }
         return undefined
     }
-    return packagePath
+    return configPath
 }
 
-function loadModuleRoots(basedir) {
-    const packagePath = findRecursively(basedir, 'package.json')
-    if (!packagePath) {
+function loadModuleRoots(basedir, configName, keys) {
+    const configPath = findRecursively(basedir, configName)
+    if (!configPath) {
         return
     }
 
-    const config = require(packagePath)
-    let roots = config && config.moduleRoots
+    const config = require(configPath)
+    let roots = config && keys(config)
     if (!roots) {
         return
     }
@@ -38,7 +38,7 @@ function loadModuleRoots(basedir) {
     }
 
     // make paths absolute and return them
-    const packageDir = path.dirname(packagePath)
+    const packageDir = path.dirname(configPath)
     return roots.map(r => path.resolve(packageDir, r))
 }
 
@@ -46,7 +46,7 @@ function loadModuleRoots(basedir) {
 function resolveWithCustomRoots(basedir, absoluteModule, resolveOptions) {
     const moduleName = `./${absoluteModule}`
 
-    const roots = loadModuleRoots(basedir)
+    const roots = loadModuleRoots(basedir, 'package.json', (config) => config.moduleRoots)
     if (!roots) {
         return
     }

--- a/src/resolve-module.js
+++ b/src/resolve-module.js
@@ -26,19 +26,19 @@ function loadModuleRoots(basedir) {
     if (!packagePath) {
         return
     }
-    const config = JSON.parse(fs.readFileSync(packagePath))
 
-    if (config && config.moduleRoots) {
-        let roots = config.moduleRoots
-        if (typeof roots === 'string') {
-            roots = [ roots ]
-        }
-
-        const packageDir = path.dirname(packagePath)
-        return roots.map(
-            r => path.resolve(packageDir , r)
-        )
+    const config = require(packagePath)
+    let roots = config && config.moduleRoots
+    if (!roots) {
+        return
     }
+
+    if (typeof roots === 'string') {
+        roots = [ roots ]
+    }
+
+    const packageDir = path.dirname(packagePath)
+    return roots.map(r => path.resolve(packageDir, r))
 }
 
 

--- a/src/resolve-module.js
+++ b/src/resolve-module.js
@@ -60,6 +60,23 @@ function resolveWithCustomRoots(basedir, absoluteModule, resolveOptions) {
     }
 }
 
+function resolveWithWebpack(basedir, absoluteModule, resolveOptions) {
+    const moduleName = `./${absoluteModule}`
+
+    const roots = loadModuleRoots(basedir, 'webpack.config.js', (config) => config.resolve && config.resolve.modules)
+    if (!roots) {
+        return
+    }
+
+    for (let i = 0; i < roots.length; i++) {
+        try {
+            return resolve(moduleName, { ...resolveOptions, basedir: roots[i] })
+        } catch (e) {
+            /* do nothing */
+        }
+    }
+}
+
 export default function resolveModule(filePath, suggestion, options = {}) {
     const { extensions = defaultExtensions } = options
     let { moduleName } = suggestion
@@ -88,7 +105,7 @@ export default function resolveModule(filePath, suggestion, options = {}) {
 
         filename = path.join(basedir, moduleName)
     } else if (!filename) {
-        filename = resolveWithCustomRoots(basedir, moduleName, resolveOptions)
+        filename = resolveWithWebpack(basedir, moduleName, resolveOptions) || resolveWithCustomRoots(basedir, moduleName, resolveOptions)
     }
 
     return { filename }

--- a/src/tests/resolve-module.test.js
+++ b/src/tests/resolve-module.test.js
@@ -99,6 +99,18 @@ describe('resolveModule', () => {
         expect(actual).toEqual(expected)
     })
 
+    test(`resolve using "modules" in webpack.config.js`, () => {
+        const suggestion = {
+            moduleName: 'all-imports'
+        }
+        const expected = {
+            filename: path.join(__dirname, './fixtures/all-imports.js')
+        }
+
+        const actual = resolveModule(__filename, suggestion, options)
+        expect(actual).toEqual(expected)
+    })
+
     test(`resolve using moduleRoots in project.json`, () => {
         const suggestion = {
             moduleName: 'parse-code'
@@ -111,7 +123,7 @@ describe('resolveModule', () => {
         expect(actual).toEqual(expected)
     })
 
-    test(`resolving when there is no package.json`, () => {
+    test(`resolving when there is no webpack.config.js or package.json`, () => {
         const suggestion = {
             moduleName: 'parse-code'
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,10 @@
+// This file is just for the tests, it doesn't compile anything
+module.exports = {
+  entry: './app.js',
+  output: {
+    filename: 'bundle.js'
+  },
+  resolve: {
+    modules: ['node_modules', 'src/tests/fixtures']
+  },
+}


### PR DESCRIPTION
After reading the FAQ section of the main README, I decided to implement the webpack path resolve because it's the most common way people do it today, and it's really easy to check, just like package.json.

It's very common in big projects to have in your `webpack.config.js` a 
```js
resolve: {
  modules: ['node_modules', 'src'],
},
```
so first, that is used to resolve the path, if it fails we check the `moduleRoots` in the `package.json`.